### PR TITLE
Fix CI for release with actions@v9

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -19,7 +19,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-
   code-style:
     name: "Code style"
     runs-on: windows-latest
@@ -49,10 +48,14 @@ jobs:
         sphinxopts: "-n -W --keep-going"
         skip-dependencies-cache: true
 
-  smoke-tests:
+  build-wheelhouse:
     name: "Build wheelhouse for latest Python versions"
     runs-on: windows-latest
     needs: code-style
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
     strategy:
        matrix:
            python-version: ['3.10', '3.11', '3.12', '3.13']
@@ -60,8 +63,9 @@ jobs:
       - uses: ansys/actions/build-wheelhouse@v9
         with:
           library-name: ${{ env.LIBRARY_NAME }}
-          operating-system: ${{ matrix.os }}
+          operating-system: "win"
           python-version: ${{ matrix.python-version }}
+          attest-provenance: true
 
   unit-tests:
     name: "Run unit tests"
@@ -78,12 +82,17 @@ jobs:
   build-library:
     name: "Build library"
     runs-on: windows-latest
-    needs: [ smoke-tests, unit-tests, doc-build ]
+    needs: [ build-wheelhouse, unit-tests, doc-build ]
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
     steps:
       - uses: ansys/actions/build-library@v9
         with:
           library-name: ${{ env.LIBRARY_NAME }}
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
+          attest-provenance: true
 
   doc-deploy-dev:
     name: "Deploy development documentation"
@@ -126,6 +135,7 @@ jobs:
         name: "Release to GitHub"
         with:
           library-name: ${{ env.LIBRARY_NAME }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   doc-deploy-stable:
     name: "Deploy stable documentation"

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -111,15 +111,15 @@ jobs:
       - name: "Download the library artifacts from build-library step"
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:
-          name: ${{ env.PACKAGE_NAME }}-artifacts
-          path: ${{ env.PACKAGE_NAME }}-artifacts
+          name: ${{ env.LIBRARY_NAME }}-artifacts
+          path: ${{ env.LIBRARY_NAME }}-artifacts
 
       - name: "Upload artifacts to PyPI using trusted publisher"
         uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
         with:
           repository-url: "https://upload.pypi.org/legacy/"
           print-hash: true
-          packages-dir: ${{ env.PACKAGE_NAME }}-artifacts
+          packages-dir: ${{ env.LIBRARY_NAME }}-artifacts
           skip-existing: false
 
       - uses: ansys/actions/release-github@v9

--- a/doc/changelog.d/115.fixed.md
+++ b/doc/changelog.d/115.fixed.md
@@ -1,0 +1,1 @@
+Fix CI for release with actions@v9

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: MIT License",
-    "Operating System :: Windows",
+    "Operating System :: Microsoft :: Windows",
 ]
 packages = [
     { include = "ansys", from = "src" },


### PR DESCRIPTION
A few fixes here for the release action and others with v9 of ansys/actions

- Fix library name in the release-public-pypi job
- Fix missing platform name in build-wheelhouse
- Add attestations
- Fix name of build-wheelhouse job
- Pass token to release-github
- Add valid trove classifier for windows