### PR TITLE
Support OIDC authentication with PyGranta clients

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3529,4 +3529,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "b634d0fab2176767de28d5054ef040e79b07d2c291d3ea9f35c058316eb0437b"
+content-hash = "7d002611363fe735e6282201d82cf84acce78cdf6bf3e4ef26e2bcce1d36921e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ packages = [
 python = ">=3.10,<4.0"
 requests = "^2.23"
 requests-negotiate-sspi = "^0.5.2"
-ansys-openapi-common = "^2.0"
+ansys-openapi-common = "^2.3.0"
 
 # Optional documentation dependencies
 [tool.poetry.group.doc]

--- a/src/ansys/grantami/dataflow_extensions/_mi_dataflow.py
+++ b/src/ansys/grantami/dataflow_extensions/_mi_dataflow.py
@@ -592,7 +592,9 @@ class MIDataflowIntegration:
             return builder.with_autologon()
 
         elif self._authentication_mode == _AuthenticationMode.OIDC_AUTHENTICATION:
-            raise NotImplementedError("OIDC authentication is not supported with PyGranta packages.")
+            logger.debug("Using OIDC authentication.")
+            access_token = self._get_oidc_token()
+            return cast(PyGranta_Connection_Class, builder.with_oidc().with_access_token(access_token=access_token))
 
         else:
             raise NotImplementedError()

--- a/src/ansys/grantami/dataflow_extensions/_mi_dataflow.py
+++ b/src/ansys/grantami/dataflow_extensions/_mi_dataflow.py
@@ -551,14 +551,6 @@ class MIDataflowIntegration:
         TypeError
             If the class provided to this method is not a subclass of
             :class:`~ansys.openapi.common.SessionConfiguration`.
-        NotImplementedError
-            If the Granta MI server is configured with OIDC authentication.
-
-        Warnings
-        --------
-        This method does not currently support OIDC. A workaround is to create the client manually and
-        authenticate with a stored OIDC refresh token. See :class:`~ansys.openapi.common.OIDCSessionBuilder`
-        for more details.
 
         Examples
         --------

--- a/tests/test_pygranta_client.py
+++ b/tests/test_pygranta_client.py
@@ -20,10 +20,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from ansys.grantami.recordlists import Connection as RecordListConnection
-from common import HTTP_SL_URL, HTTPS_SL_URL, PASSWORD, USERNAME
+from common import HTTP_SL_URL, HTTPS_SL_URL, PASSWORD, USERNAME, access_token
 import pytest
 
 # Don't try and merge a test with its associated '_url' test. The act of mocking the
@@ -96,6 +96,16 @@ def test_oidc_https(oidc_https, debug_caplog):
     mock.assert_called_once_with()
     assert _pygranta_client_logged(debug_caplog.text)
     assert "Using OIDC authentication." in debug_caplog.text
+
+
+def test_oidc_https_auth_token(oidc_https, debug_caplog):
+    oidc_builder = MagicMock()
+    oidc_builder.with_access_token = MagicMock()
+    with_oidc_mock = MagicMock(return_value=oidc_builder)
+
+    with patch("ansys.openapi.common.ApiClientFactory.with_oidc", with_oidc_mock):
+        oidc_https.dataflow_integration.configure_pygranta_connection(RecordListConnection).connect()
+    oidc_builder.with_access_token.assert_called_once_with(access_token=access_token)
 
 
 def test_invalid_class_raises_exception(windows_https):

--- a/tests/test_pygranta_client.py
+++ b/tests/test_pygranta_client.py
@@ -90,9 +90,12 @@ def test_basic_http_url(basic_http):
     assert client._service_layer_url == HTTP_SL_URL
 
 
-def test_oidc_raises_exception(oidc_https, debug_caplog):
-    with pytest.raises(NotImplementedError, match="OIDC authentication is not supported with PyGranta packages"):
+def test_oidc_https(oidc_https, debug_caplog):
+    with patch.object(RecordListConnection, "with_oidc") as mock:
         oidc_https.dataflow_integration.configure_pygranta_connection(RecordListConnection).connect()
+    mock.assert_called_once_with()
+    assert _pygranta_client_logged(debug_caplog.text)
+    assert "Using OIDC authentication." in debug_caplog.text
 
 
 def test_invalid_class_raises_exception(windows_https):

--- a/tests/test_pygranta_client.py
+++ b/tests/test_pygranta_client.py
@@ -23,6 +23,7 @@
 from unittest.mock import MagicMock, patch
 
 from ansys.grantami.recordlists import Connection as RecordListConnection
+from ansys.openapi.common import OIDCSessionBuilder
 from common import HTTP_SL_URL, HTTPS_SL_URL, PASSWORD, USERNAME, access_token
 import pytest
 
@@ -99,8 +100,7 @@ def test_oidc_https(oidc_https, debug_caplog):
 
 
 def test_oidc_https_auth_token(oidc_https, debug_caplog):
-    oidc_builder = MagicMock()
-    oidc_builder.with_access_token = MagicMock()
+    oidc_builder = MagicMock(spec_set=OIDCSessionBuilder)
     with_oidc_mock = MagicMock(return_value=oidc_builder)
 
     with patch("ansys.openapi.common.ApiClientFactory.with_oidc", with_oidc_mock):


### PR DESCRIPTION
Closes #28 

Add support for creating OIDC-based PyGranta clients. Uses the provided access token to create the client directly. Requires an upgrade to openapi-common.

Added some unit tests to check the right calls are being made with the correct parameters. Also tested manually against Granta MI configured in OIDC mode. Confirmed that the RecordList example can be run, and that the certificate can be provided explicitly instead of relying on pip-system-certs. This is because the client never needs to talk to the IdP directly.