### PR TITLE
Allow the configuration of PyGranta and Scripting Toolkit sessions

### DIFF
--- a/tests/test_scripting_toolkit_session.py
+++ b/tests/test_scripting_toolkit_session.py
@@ -22,64 +22,145 @@
 
 from common import HTTP_SL_URL, HTTPS_SL_URL, PASSWORD, USERNAME, access_token
 from mocks.scripting_toolkit import mpy as mpy_mock
+import pytest
+
+timeout_params = pytest.mark.parametrize("timeout", [None, 1_000_000])
+max_retries_params = pytest.mark.parametrize("retries", [None, 10])
 
 
-def test_windows_https(windows_https, debug_caplog):
-    mpy_mock.connect.reset_mock()
-    _ = windows_https.dataflow_integration.mi_session
-    mpy_mock.connect.assert_called_once_with(
-        HTTPS_SL_URL,
-        autologon=True,
-    )
-    assert _scripting_toolkit_logged(debug_caplog.text)
-    assert "Using Windows authentication." in debug_caplog.text
+@timeout_params
+@max_retries_params
+class TestScriptingToolkitSession:
+    def test_windows_https(self, timeout, retries, windows_https, debug_caplog):
+        mpy_mock.connect.reset_mock()
+        kwargs = self._kwargs(timeout, retries)
+        _ = windows_https.dataflow_integration.get_scripting_toolkit_session(**kwargs)
+        mpy_mock.connect.assert_called_once_with(
+            HTTPS_SL_URL,
+            autologon=True,
+            **kwargs,
+        )
+        assert _scripting_toolkit_logged(debug_caplog.text)
+        assert "Using Windows authentication." in debug_caplog.text
+
+    def test_windows_http(self, timeout, retries, windows_http, debug_caplog):
+        mpy_mock.connect.reset_mock()
+        kwargs = self._kwargs(timeout, retries)
+        _ = windows_http.dataflow_integration.get_scripting_toolkit_session(**kwargs)
+        mpy_mock.connect.assert_called_once_with(
+            HTTP_SL_URL,
+            autologon=True,
+            **kwargs,
+        )
+        assert _scripting_toolkit_logged(debug_caplog.text)
+        assert "Using Windows authentication." in debug_caplog.text
+
+    def test_basic_https(self, timeout, retries, basic_https, debug_caplog):
+        mpy_mock.connect.reset_mock()
+        kwargs = self._kwargs(timeout, retries)
+        _ = basic_https.dataflow_integration.get_scripting_toolkit_session(**kwargs)
+        mpy_mock.connect.assert_called_once_with(
+            HTTPS_SL_URL,
+            user_name=USERNAME,
+            password=PASSWORD,
+            **kwargs,
+        )
+        assert _scripting_toolkit_logged(debug_caplog.text)
+        assert "Using Basic authentication." in debug_caplog.text
+
+    def test_basic_http(self, timeout, retries, basic_http, debug_caplog):
+        mpy_mock.connect.reset_mock()
+        kwargs = self._kwargs(timeout, retries)
+        _ = basic_http.dataflow_integration.get_scripting_toolkit_session(**kwargs)
+        mpy_mock.connect.assert_called_once_with(
+            HTTP_SL_URL,
+            user_name=USERNAME,
+            password=PASSWORD,
+            **kwargs,
+        )
+        assert _scripting_toolkit_logged(debug_caplog.text)
+        assert "Using Basic authentication." in debug_caplog.text
+
+    def test_oidc_https(self, timeout, retries, oidc_https, debug_caplog):
+        mpy_mock.connect.reset_mock()
+        kwargs = self._kwargs(timeout, retries)
+        _ = oidc_https.dataflow_integration.get_scripting_toolkit_session(**kwargs)
+        mpy_mock.connect.assert_called_once_with(
+            HTTPS_SL_URL,
+            oidc=True,
+            auth_token=access_token,
+            **kwargs,
+        )
+        assert _scripting_toolkit_logged(debug_caplog.text)
+        assert "Using OIDC authentication." in debug_caplog.text
+
+    def _kwargs(self, timeout, retries):
+        kwargs = {}
+        if timeout is not None:
+            kwargs["timeout"] = timeout
+        if retries is not None:
+            kwargs["max_retries"] = retries
+        return kwargs
 
 
-def test_windows_http(windows_http, debug_caplog):
-    mpy_mock.connect.reset_mock()
-    _ = windows_http.dataflow_integration.mi_session
-    mpy_mock.connect.assert_called_once_with(
-        HTTP_SL_URL,
-        autologon=True,
-    )
-    assert _scripting_toolkit_logged(debug_caplog.text)
-    assert "Using Windows authentication." in debug_caplog.text
+class TestDeprecatedScriptingToolkit:
+    def test_windows_https_deprecated_property(self, windows_https, debug_caplog):
+        mpy_mock.connect.reset_mock()
+        with pytest.warns(match=r"This method is deprecated\. Use 'get_scripting_toolkit_session\(\)' instead\."):
+            _ = windows_https.dataflow_integration.mi_session
+        mpy_mock.connect.assert_called_once_with(
+            HTTPS_SL_URL,
+            autologon=True,
+        )
+        assert _scripting_toolkit_logged(debug_caplog.text)
+        assert "Using Windows authentication." in debug_caplog.text
 
+    def test_windows_http(self, windows_http, debug_caplog):
+        mpy_mock.connect.reset_mock()
+        with pytest.warns(match=r"This method is deprecated\. Use 'get_scripting_toolkit_session\(\)' instead\."):
+            _ = windows_http.dataflow_integration.mi_session
+        mpy_mock.connect.assert_called_once_with(
+            HTTP_SL_URL,
+            autologon=True,
+        )
+        assert _scripting_toolkit_logged(debug_caplog.text)
+        assert "Using Windows authentication." in debug_caplog.text
 
-def test_basic_https(basic_https, debug_caplog):
-    mpy_mock.connect.reset_mock()
-    _ = basic_https.dataflow_integration.mi_session
-    mpy_mock.connect.assert_called_once_with(
-        HTTPS_SL_URL,
-        user_name=USERNAME,
-        password=PASSWORD,
-    )
-    assert _scripting_toolkit_logged(debug_caplog.text)
-    assert "Using Basic authentication." in debug_caplog.text
+    def test_basic_https(self, basic_https, debug_caplog):
+        mpy_mock.connect.reset_mock()
+        with pytest.warns(match=r"This method is deprecated\. Use 'get_scripting_toolkit_session\(\)' instead\."):
+            _ = basic_https.dataflow_integration.mi_session
+        mpy_mock.connect.assert_called_once_with(
+            HTTPS_SL_URL,
+            user_name=USERNAME,
+            password=PASSWORD,
+        )
+        assert _scripting_toolkit_logged(debug_caplog.text)
+        assert "Using Basic authentication." in debug_caplog.text
 
+    def test_basic_http(self, basic_http, debug_caplog):
+        mpy_mock.connect.reset_mock()
+        with pytest.warns(match=r"This method is deprecated\. Use 'get_scripting_toolkit_session\(\)' instead\."):
+            _ = basic_http.dataflow_integration.mi_session
+        mpy_mock.connect.assert_called_once_with(
+            HTTP_SL_URL,
+            user_name=USERNAME,
+            password=PASSWORD,
+        )
+        assert _scripting_toolkit_logged(debug_caplog.text)
+        assert "Using Basic authentication." in debug_caplog.text
 
-def test_basic_http(basic_http, debug_caplog):
-    mpy_mock.connect.reset_mock()
-    _ = basic_http.dataflow_integration.mi_session
-    mpy_mock.connect.assert_called_once_with(
-        HTTP_SL_URL,
-        user_name=USERNAME,
-        password=PASSWORD,
-    )
-    assert _scripting_toolkit_logged(debug_caplog.text)
-    assert "Using Basic authentication." in debug_caplog.text
-
-
-def test_oidc_https(oidc_https, debug_caplog):
-    mpy_mock.connect.reset_mock()
-    _ = oidc_https.dataflow_integration.mi_session
-    mpy_mock.connect.assert_called_once_with(
-        HTTPS_SL_URL,
-        oidc=True,
-        auth_token=access_token,
-    )
-    assert _scripting_toolkit_logged(debug_caplog.text)
-    assert "Using OIDC authentication." in debug_caplog.text
+    def test_oidc_https(self, oidc_https, debug_caplog):
+        mpy_mock.connect.reset_mock()
+        with pytest.warns(match=r"This method is deprecated\. Use 'get_scripting_toolkit_session\(\)' instead\."):
+            _ = oidc_https.dataflow_integration.mi_session
+        mpy_mock.connect.assert_called_once_with(
+            HTTPS_SL_URL,
+            oidc=True,
+            auth_token=access_token,
+        )
+        assert _scripting_toolkit_logged(debug_caplog.text)
+        assert "Using OIDC authentication." in debug_caplog.text
 
 
 def _scripting_toolkit_logged(log):


### PR DESCRIPTION
Closes #26 

Add the ability to configure PyGranta and Scripting Toolkit sessions:

* The PyGranta client creation method now accepts a SessionConfiguration object. The docstring warns that the verify_ssl and cert_store_path args will be overridden if specified
* The Scripting Toolkit client creation accepts retry and timeout arguments. Default behavior is delegated entirely to Scripting Toolkit, and the values are only provided to the Session constructor if they are non-null.

The associated ticket states that we could use `ansys.openapi.common` to create all the sessions, but this isn't really possible currently. We'd have to use private methods/attributes within the library, which would make maintenance difficult.